### PR TITLE
Update to use capybara_minitest_spec 1.0.6.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :development, :test do
 
   gem 'cucumber-rails', require: false
   gem 'minitest-rails-capybara'
-  gem 'capybara_minitest_spec'
+  gem 'capybara_minitest_spec', '1.0.6'
   gem 'database_cleaner'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara_minitest_spec (1.0.5)
+    capybara_minitest_spec (1.0.6)
       capybara (>= 2)
       minitest (>= 4)
     coffee-rails (4.1.0)
@@ -182,7 +182,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
-  capybara_minitest_spec
+  capybara_minitest_spec (= 1.0.6)
   coffee-rails (~> 4.1.0)
   cucumber-rails
   database_cleaner

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,6 +5,7 @@
 # files.
 
 require 'cucumber/rails'
+require 'capybara_minitest_spec/cucumber_rails'
 
 # Capybara defaults to CSS3 selectors rather than XPath.
 # If you'd prefer to use XPath, just uncomment this line and adjust any


### PR DESCRIPTION
To try:
- Clone capybara_minitest_spec and cd into it.
- `git checkout cucumber_rails` (from https://github.com/ordinaryzelig/capybara_minitest_spec/pull/16)
- `rake install`.
- Back in bug-demo, `cucumber` should work now.
